### PR TITLE
Apostrophe fix

### DIFF
--- a/R/prisma.r
+++ b/R/prisma.r
@@ -1,7 +1,7 @@
 #' Generate a PRISMA statement flow chart
 #'
-#' Generate PRISMA statement flow chart for use in retrospective medical
-#' research. Almost all arguments are mandatory, as they are in the recommended
+#' Generate PRISMA statement flow chart for use in literature
+#' research and reviews. Almost all arguments are mandatory, as they are in the recommended
 #' PRISMA statement.
 #' @param found Records found through database searching
 #' @param found_other Additional records identified through other sources

--- a/R/prisma.r
+++ b/R/prisma.r
@@ -145,6 +145,8 @@ prisma_graph <- function(found,
   if (full_text - full_text_exclusions != qualitative)
     warning("After full-text exclusions, a different number of remaining ",
             "articles for qualitative synthesis is stated.")
+  # apostrophes need to be replaced for grViz
+  labels <- lapply(labels, gsub, pattern = "'", replace = "&rsquo;")
   dupes <- found + found_other - no_dupes
   labels_orig <- list(
     found = pnl("Records identified through",

--- a/tests/testthat/test-prisma.r
+++ b/tests/testthat/test-prisma.r
@@ -90,6 +90,21 @@ test_that("change a label", {
     regexp = NA)
 })
 
+test_that("use an apostrophe in a label", {
+  expect_error(
+    prisma(found = 0,
+           found_other = 0,
+           no_dupes = 0,
+           screened = 0,
+           screen_exclusions = 0,
+           full_text = 0,
+           full_text_exclusions = 0,
+           qualitative = 0,
+           quantitative = 0,
+           labels = list(screened = "PLEASE DON'T RETURN AN ERROR")),
+    regexp = NA)
+})
+
 test_that("numbers must work together", {
   expect_error(prisma(1, 2, 3, 4, 5, 6, 7, 8, 9))
   expect_warning(prisma(1000, 20, 270, 270, 10, 260, 19, 240, 107))


### PR DESCRIPTION
This fixes a bug which prevented using apostrophes in custom labels.

`DiagrammeR::grViz` does not accept `'` in labels and escaping them won't work, because they get replaced with `"` in the process.

This fix replaces apostrophes (`'`) in custom labels with HTML `&rsquo;`.